### PR TITLE
Add negative slicing support

### DIFF
--- a/superstring/superstring.py
+++ b/superstring/superstring.py
@@ -77,7 +77,7 @@ class SuperStringBase(object):
             start = key.start if key.start > 0 else self.length() + key.start
             stop = key.stop if key.stop > 0 else self.length() + key.stop
             return self.substring(start, end_index=stop)
-        return self.character_at(key)
+        return self.characterAt(key)
 
 class SuperString(SuperStringBase):
     def __init__(self, content):

--- a/superstring/superstring.py
+++ b/superstring/superstring.py
@@ -73,10 +73,11 @@ class SuperStringBase(object):
         return self.toPrintable()
 
     def __getitem__(self, key):
-        # TODO: Negative Indexing
         if isinstance(key, slice):
-            return self.substring(key.start, endIndex = key.stop)
-        return self.characterAt(key)
+            start = key.start if key.start > 0 else self.length() + key.start
+            stop = key.stop if key.stop > 0 else self.length() + key.stop
+            return self.substring(start, end_index=stop)
+        return self.character_at(key)
 
 class SuperString(SuperStringBase):
     def __init__(self, content):


### PR DESCRIPTION
For slicing (i.e; `[1:-1]`), add support for negative values by adding the length to the value. Basic idea:

```
test = "test"
test[1:-1] == "es" # True
test[1:len(test) - 1] == "es"  # True
test[1:len(test) - 1]  == test[1:-1] # True
``` 